### PR TITLE
Simplify knowledge path detection

### DIFF
--- a/eu5_agent/config.py
+++ b/eu5_agent/config.py
@@ -50,9 +50,7 @@ class EU5Config:
 
         # Knowledge Base Configuration
         # Set to None to trigger auto-detection in knowledge.py
-        # This enables backward-compatible path detection for both:
-        # - pip-installed package (knowledge inside eu5_agent/)
-        # - source repository (knowledge at repository root via symlink)
+        # Auto-detection uses the packaged knowledge at eu5_agent/knowledge
         self.knowledge_path = os.getenv("EU5_KNOWLEDGE_PATH", None)
 
         # Web Search Configuration (Optional)

--- a/eu5_agent/knowledge.py
+++ b/eu5_agent/knowledge.py
@@ -60,29 +60,14 @@ class EU5Knowledge:
             knowledge_path = os.getenv("EU5_KNOWLEDGE_PATH", None)
 
             if knowledge_path is None:
-                # Auto-detect knowledge base location
-                # Supports both pip-installed package and source repository
+                # Auto-detect knowledge base location (package relative)
                 package_dir = Path(__file__).parent
 
-                # Try package-relative path first (pip install, new structure)
                 # Path(__file__) = .../eu5_agent/knowledge.py
                 # .parent = eu5_agent package directory
                 # / "knowledge" = knowledge directory inside package
                 pkg_knowledge = package_dir / "knowledge"
-
-                if pkg_knowledge.exists():
-                    # New structure: knowledge inside package (pip install)
-                    knowledge_path = str(pkg_knowledge)
-                else:
-                    # Fall back to repository structure (running from source)
-                    # Path(__file__).parent.parent = repository root
-                    # / "knowledge" = knowledge directory at repo root (via symlink)
-                    repo_knowledge = package_dir.parent / "knowledge"
-                    if repo_knowledge.exists():
-                        knowledge_path = str(repo_knowledge)
-                    else:
-                        # Neither location found, default to package-relative
-                        knowledge_path = str(pkg_knowledge)
+                knowledge_path = str(pkg_knowledge)
 
         self.knowledge_path = Path(knowledge_path)
 

--- a/knowledge
+++ b/knowledge
@@ -1,1 +1,0 @@
-eu5_agent/knowledge

--- a/tests/test_knowledge_unit.py
+++ b/tests/test_knowledge_unit.py
@@ -3,7 +3,6 @@ Unit tests for EU5 Knowledge Base (eu5_agent/knowledge.py).
 
 Tests cover:
 - Auto-detection logic for pip-installed package structure
-- Auto-detection fallback to repository structure (symlink)
 - Environment variable override (EU5_KNOWLEDGE_PATH)
 - Error handling when knowledge base directory missing
 - Category-based file organization
@@ -55,28 +54,6 @@ class TestKnowledgeInitialization:
 
             # Should find knowledge in package directory without raising exception
             EU5Knowledge()
-
-    def test_auto_detect_repository_structure(self, tmp_path):
-        """Test auto-detection fallback to repository structure."""
-        # This test verifies the fallback logic is present, but the complex
-        # path mocking is difficult. We'll test the actual behavior through
-        # integration instead. This test just verifies no exception when
-        # the auto-detection logic runs.
-
-        # Create repo structure: repo_root/knowledge/
-        repo_root = tmp_path
-        knowledge_dir = repo_root / "knowledge"
-        knowledge_dir.mkdir()
-
-        # Create package dir without knowledge
-        package_dir = repo_root / "eu5_agent"
-        package_dir.mkdir()
-
-        # For this test, we'll just verify the logic handles the fallback path
-        # The actual auto-detection is tested via integration tests
-        assert knowledge_dir.exists()
-        assert not (package_dir / "knowledge").exists()
-        # Test passes if no exception is raised during structure verification
 
 
 class TestKnowledgeCategories:


### PR DESCRIPTION
## Summary
- Remove repo-root knowledge symlink and rely on packaged eu5_agent/knowledge
- Simplify knowledge auto-detection to the packaged path and update config comments
- Drop obsolete repository fallback test

## Testing
- pytest tests/test_knowledge_unit.py