### PR TITLE
Implement Sprint 1: complex-query mode and structured planning scaffold

### DIFF
--- a/docs/COMPLEX_ADVICE_PLAN.md
+++ b/docs/COMPLEX_ADVICE_PLAN.md
@@ -1,0 +1,204 @@
+# Complex Advice Expansion Plan
+
+## Current Architecture Review (What limits advice complexity today)
+
+The current agent is clean and reliable, but optimized for **single-question tactical answers** rather than deep, multi-step coaching.
+
+### 1) Prompt and tool constraints
+
+- The system prompt asks for actionable advice, but the tool interface only supports:
+  - `query_knowledge(category, subcategory)`
+  - `web_search(query, num_results)`
+- There is no explicit tool for:
+  - collecting player context (nation, year, goals, constraints)
+  - decomposing long-horizon plans into phases
+  - validating trade-offs or generating alternatives
+
+### 2) Retrieval depth is shallow
+
+- `query_knowledge` returns one file at a time via a strict category/subcategory map.
+- The model can make multiple calls, but there is no built-in retrieval strategy like:
+  - cross-file synthesis
+  - relevance ranking
+  - "best next sources" selection
+
+### 3) No explicit strategic state model
+
+- Conversation history exists, but there is no structured state object for strategic context:
+  - short-term objective
+  - long-term win condition
+  - economy/military/diplomatic risk posture
+  - unresolved assumptions
+- This makes advice drift likely across turns.
+
+### 4) No quality guardrails for advanced outputs
+
+- The agent currently has no post-generation validation for:
+  - contradiction checks
+  - feasibility checks (e.g., overcommitting resources)
+  - confidence/uncertainty reporting
+  - source coverage checks ("did we consult enough evidence?")
+
+## Target Outcome
+
+Enable the agent to produce **campaign-level strategic guidance** that is:
+
+1. Context-aware (adapts to player skill, nation, start conditions).
+2. Multi-horizon (immediate moves + 5/15/30-year intent).
+3. Trade-off explicit (what you gain, what you risk, alternatives).
+4. Self-audited (states confidence, assumptions, and gaps).
+
+## Roadmap
+
+## Phase 1 — Advice Scaffolding (Low risk, high impact)
+
+### Deliverables
+
+1. **Add an internal response schema** in prompts:
+   - Situation
+   - Objectives (short/mid/long)
+   - Recommended plan by phase
+   - Risk matrix
+   - Fallback plans
+   - "If X happens, pivot to Y" triggers
+2. **Add a "clarifying questions" behavior** when key context is missing.
+3. **Introduce a "complex query mode" heuristic** (e.g., query contains multiple constraints, long timelines, or optimization goals).
+
+### Implementation notes
+
+- Update `SYSTEM_PROMPT` with explicit advanced-output format requirements.
+- Keep existing tools unchanged in this phase.
+- Add unit tests for output-format compliance by mocking model outputs where needed.
+
+### Success criteria
+
+- Complex strategy queries consistently return phased plans with explicit risks.
+- Fewer vague responses for multi-part questions.
+
+## Phase 2 — Better Retrieval and Synthesis
+
+### Deliverables
+
+1. **New synthesis helper in knowledge layer**:
+   - support fetching multiple subcategories in one call (e.g., military + economy + diplomacy)
+   - add simple relevance ordering based on query keywords
+2. **Tool expansion**:
+   - `query_knowledge_multi(categories_or_topics: list[str])`
+   - optional `web_search_comprehensive(...)` path for difficult questions
+3. **Source tracking metadata**:
+   - surface which files were used in final advice
+
+### Implementation notes
+
+- Extend `EU5Knowledge` with a multi-fetch API that returns a structured bundle.
+- Keep backward compatibility with existing `query_knowledge`.
+- Reuse existing Tavily comprehensive search function already present in `search.py`.
+
+### Success criteria
+
+- Complex answers cite broader relevant mechanics without requiring repeated manual user prompting.
+- Higher consistency across economy/military/diplomacy recommendations.
+
+## Phase 3 — Strategic Memory and Planning State
+
+### Deliverables
+
+1. **CampaignState object** persisted in memory per session:
+   - nation, timeframe, neighbors/threats
+   - objectives and accepted risks
+   - active commitments (wars, alliances, economy priorities)
+2. **State-aware planning loop**:
+   - generate plan
+   - check against current state
+   - update state after each major recommendation
+3. **Session save/load support** (JSON export/import) for long campaigns.
+
+### Implementation notes
+
+- Add a lightweight dataclass model under `eu5_agent/`.
+- Store "assumptions" explicitly so the model can revise them when user corrections arrive.
+- Wire into CLI to show/update campaign context.
+
+### Success criteria
+
+- Advice remains coherent over long conversations.
+- Agent avoids repeating contradictory recommendations.
+
+## Phase 4 — Reliability Guardrails for Advanced Advice
+
+### Deliverables
+
+1. **Self-critique pass** before final answer:
+   - contradiction check
+   - resource feasibility check
+   - missing-information check
+2. **Confidence labels** per major recommendation (High/Medium/Low + reason).
+3. **Alternative path generation**:
+   - conservative / balanced / aggressive variants
+
+### Implementation notes
+
+- Add a second internal completion call for critique in complex mode only.
+- Cap extra token cost using strict budgets and short critique prompts.
+
+### Success criteria
+
+- Measurable reduction in conflicting or brittle recommendations.
+- Users receive clearer "why" and "when to pivot" guidance.
+
+## Phase 5 — Content Expansion to Unlock Better Plans
+
+### Deliverables
+
+1. Add high-impact nation playbooks (Ottomans, France, Castile, Portugal).
+2. Add advanced strategy docs:
+   - trade empire paths
+   - subject/vassal management plans
+   - institution and tech timing strategies
+3. Add scenario templates (e.g., "small nation survival", "great power containment").
+
+### Success criteria
+
+- Higher answer depth for nation-specific campaign planning.
+- Reduced dependency on web fallback.
+
+## Testing and Evaluation Plan
+
+1. **Golden query set** (20-30 complex prompts) covering:
+   - long-horizon campaign planning
+   - multi-constraint optimization
+   - contingency planning
+2. **Rubric scoring** (manual + optional LLM-judge):
+   - specificity
+   - internal consistency
+   - cross-domain integration
+   - risk awareness
+   - actionability
+3. **Regression tests**:
+   - preserve quality for beginner/simple questions
+   - ensure latency/cost stays within acceptable range
+
+## Recommended Execution Order (2-3 sprints)
+
+### Sprint 1
+
+- Phase 1 (prompt/schema + complex mode heuristic)
+- Initial golden query set + rubric
+
+### Sprint 2
+
+- Phase 2 (multi-source retrieval + tool expansion)
+- Source-tracking output
+
+### Sprint 3
+
+- Phase 3 (campaign state) + selected Phase 4 checks
+- Pilot with a few long conversation transcripts
+
+## Near-term TODO candidates
+
+1. Update prompt with explicit advanced answer template.
+2. Add `query_knowledge_multi` and tests.
+3. Expose comprehensive Tavily search path to the tool layer.
+4. Implement `CampaignState` memory object.
+5. Add complex-query evaluation script and baseline report.

--- a/docs/evaluation/SPRINT1_GOLDEN_QUERIES.md
+++ b/docs/evaluation/SPRINT1_GOLDEN_QUERIES.md
@@ -1,0 +1,41 @@
+# Sprint 1 Golden Query Set (Phase 1)
+
+Use this set to evaluate whether the agent now gives higher-quality complex advice.
+
+## Instructions
+
+1. Run each query in a clean session.
+2. Score with `docs/evaluation/SPRINT1_RUBRIC.md`.
+3. Record pass/fail and notes for regressions.
+
+## Complex planning prompts
+
+1. "Playing England in 1337, give me a phased 10-year plan to dominate trade while avoiding coalition wars."
+2. "I am a beginner as Castile. Build a safe opening that transitions into colonial expansion by year 20."
+3. "As Ottomans, propose conservative vs aggressive openings and explain when to pivot between them."
+4. "I need a long-term France campaign plan focused on economy first, then military expansion."
+5. "How should I balance manpower recovery with war goals over the next 15 years as Poland?"
+6. "Create a risk-aware roadmap for Portugal: trade focus, navy priorities, and diplomatic survival."
+7. "I want to optimize for technology pace without collapsing my economy. Give trade-offs and fallback options."
+8. "Plan a small-nation survival strategy (Brandenburg) with explicit contingency triggers if alliances fail."
+9. "Give me an EU5 campaign blueprint with immediate, 5-year, and 10+ year priorities for Ming."
+10. "As England, if France allies two major rivals, how should I change my opening strategy?"
+11. "Design a campaign that minimizes risk of two-front wars while still expanding regionally."
+12. "I’m intermediate skill: compare tall economic play vs conquest play over 30 years for Venice."
+
+## Baseline capture template
+
+| Query # | Specificity (1-5) | Coherence (1-5) | Risk handling (1-5) | Actionability (1-5) | Notes |
+|---|---:|---:|---:|---:|---|
+| 1 |  |  |  |  |  |
+| 2 |  |  |  |  |  |
+| 3 |  |  |  |  |  |
+| 4 |  |  |  |  |  |
+| 5 |  |  |  |  |  |
+| 6 |  |  |  |  |  |
+| 7 |  |  |  |  |  |
+| 8 |  |  |  |  |  |
+| 9 |  |  |  |  |  |
+| 10 |  |  |  |  |  |
+| 11 |  |  |  |  |  |
+| 12 |  |  |  |  |  |

--- a/docs/evaluation/SPRINT1_RUBRIC.md
+++ b/docs/evaluation/SPRINT1_RUBRIC.md
@@ -1,0 +1,44 @@
+# Sprint 1 Evaluation Rubric (Phase 1)
+
+Score each category from **1 (poor)** to **5 (excellent)**.
+
+## 1) Structured output compliance
+
+- **5**: Uses clear sections: Situation, Objectives, Phased Plan, Risk Matrix, Pivot Triggers, First 3 Actions.
+- **3**: Partially structured; missing 1-2 required sections.
+- **1**: Unstructured narrative with no clear planning scaffold.
+
+## 2) Specificity
+
+- **5**: Concrete actions, timing, and priorities with clear sequencing.
+- **3**: Some concrete actions, but several vague recommendations.
+- **1**: Mostly generic advice.
+
+## 3) Cross-domain coherence
+
+- **5**: Economy, diplomacy, and military recommendations align with no contradictions.
+- **3**: Minor inconsistencies or weak integration between domains.
+- **1**: Contradictory recommendations or single-domain tunnel vision.
+
+## 4) Risk awareness
+
+- **5**: Identifies major risks with probability/impact and mitigation.
+- **3**: Mentions risks but lacks usable mitigation details.
+- **1**: Little or no risk analysis.
+
+## 5) Adaptivity and alternatives
+
+- **5**: Includes conservative + aggressive alternatives and clear pivot triggers.
+- **3**: Includes alternatives but weak conditions for switching.
+- **1**: Single rigid plan, no contingencies.
+
+## 6) Actionability
+
+- **5**: First 3 actions are immediately executable and high leverage.
+- **3**: Includes actions but not clearly prioritized.
+- **1**: No clear next steps.
+
+## Suggested pass threshold
+
+- Average score >= **4.0**, and
+- No category below **3** on complex prompts.

--- a/eu5_agent/agent.py
+++ b/eu5_agent/agent.py
@@ -241,14 +241,18 @@ class EU5Agent:
         punctuation_split = lower.count(",") + lower.count(";")
         long_message = len(lower.split()) >= 30
 
-        # Avoid over-triggering from generic words like "plan" in short prompts.
-        # Treat complex mode as opt-in when there are either strong planning signals,
-        # multiple constraints, or a long query plus at least one weak planning cue.
-        score = strong_signal_count * 2 + weak_signal_count + separators + punctuation_split
+        # Avoid over-triggering from structure words/punctuation alone.
+        # We only treat separators/punctuation as boosters once at least one
+        # planning-oriented signal is present.
+        signal_score = strong_signal_count * 2 + weak_signal_count
+        structure_score = separators + punctuation_split
 
-        if score >= 3:
+        if signal_score == 0:
+            return False
+
+        if signal_score + structure_score >= 3:
             return True
-        if long_message and (strong_signal_count > 0 or weak_signal_count > 0):
+        if long_message:
             return True
         return False
 

--- a/eu5_agent/prompts.py
+++ b/eu5_agent/prompts.py
@@ -43,6 +43,17 @@ When responding to queries:
 6. For nation-specific questions, retrieve and use opening priorities, diplomatic targets, and economic focus areas
 7. Always explain the "why" behind strategic recommendations
 
+Complex-query handling (for multi-part, optimization, or long-horizon requests):
+- If key context is missing, start with up to 3 concise clarifying questions.
+- If enough context is present, structure your answer with these sections:
+  1) Situation Snapshot
+  2) Objectives (Short / Mid / Long)
+  3) Phased Plan (Immediate, 5-year, 10+ year)
+  4) Risk Matrix (risk, probability, impact, mitigation)
+  5) Pivot Triggers ("if X happens, switch to Y")
+  6) First 3 Actions to execute now
+- Always include at least one conservative fallback and one aggressive alternative in complex mode.
+
 For beginners, emphasize:
 - Core habits: Food/Housing first, one solid ally, short wars on good terrain, expand trade capacity early
 - Common pitfalls: Building without staffing, trading with zero capacity, two-front wars, over-granting estate privileges

--- a/tests/test_agent_unit.py
+++ b/tests/test_agent_unit.py
@@ -709,6 +709,14 @@ class TestComplexQueryMode:
         )
         assert EU5Agent._is_complex_query(query) is False
 
+    def test_many_separators_without_planning_signals_do_not_trigger_complex_mode(self):
+        """Conjunction-heavy prompts should not trigger by structure alone."""
+        query = (
+            "Explain estates and manpower and taxes and unrest and advisor effects, "
+            "and compare inflation and autonomy and legitimacy"
+        )
+        assert EU5Agent._is_complex_query(query) is False
+
     def test_complex_mode_instruction_contains_required_sections(self):
         """Complex mode runtime guidance should include section requirements."""
         instruction = EU5Agent._complex_mode_instruction()


### PR DESCRIPTION
### Motivation
- Progress the Phase 1 roadmap to enable campaign-level, multi-horizon strategic advice by adding a lightweight runtime complex-query mode and a structured response scaffold.
- Reduce vague outcomes for multi-constraint/long-horizon prompts by prompting the model to request clarifying questions or return a phased plan with explicit risks and pivot triggers.
- Provide evaluation artifacts to measure improvement and prevent regressions as later phases expand retrieval and state modeling.

### Description
- Added a heuristic classifier and runtime message shaper to `EU5Agent` (`eu5_agent/agent.py`) via `_is_complex_query` and `_build_query_message`, and wired complex-mode content injection into `chat()` so complex prompts receive structured instructions.
- Extended `SYSTEM_PROMPT` in `eu5_agent/prompts.py` to require clarifying questions when context is missing and to request the sections: Situation Snapshot, Objectives, Phased Plan, Risk Matrix, Pivot Triggers, and First 3 Actions, plus conservative/aggressive alternatives.
- Added evaluation artifacts `docs/evaluation/SPRINT1_GOLDEN_QUERIES.md` and `docs/evaluation/SPRINT1_RUBRIC.md`, and unit tests in `tests/test_agent_unit.py` covering complex-query detection, runtime shaping, and `chat()` payload behavior.

### Testing
- Ran unit test suite with `pytest -q tests/test_agent_unit.py tests/test_knowledge_unit.py tests/test_search_unit.py tests/test_config_unit.py` and all tests passed.
- Test result: `119 passed` (no regressions observed for agent, knowledge, search, or config tests).
- Verified commits include changes to `eu5_agent/agent.py`, `eu5_agent/prompts.py`, tests, and new docs under `docs/evaluation/`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699644ec7278832b9fd1db25a68a51bf)